### PR TITLE
ci: fix broken pak symlinks in setup-r-dependencies cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       cancel-in-progress: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_CONFIG_AUTOLOADER_ENABLED: FALSE
     # defaults:
     #   run:
     #     shell: bash -l {0}
@@ -46,6 +47,7 @@ jobs:
       - name: Install R dependencies for unfrozen pages
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: 2
           packages: |
             any::googlesheets4
             any::gt


### PR DESCRIPTION
## Summary
- Bumps `cache-version` on `r-lib/actions/setup-r-dependencies@v2` to invalidate the cache that was holding broken `pak` symlinks into renv's package cache.
- Sets `RENV_CONFIG_AUTOLOADER_ENABLED: FALSE` at the job level so `.Rprofile`'s renv autoloader doesn't activate during CI — matching the workflow's stated intent of not using renv for the build (`freeze: auto` covers it).

## Why
The last `Build Site` run failed at `Install R dependencies for unfrozen pages`:

```
The following package(s) have broken symlinks into the cache:
- pak
Error in library(pak, lib.loc = Sys.getenv("R_LIB_FOR_PAK")) :
  there is no package called 'pak'
```

The cached library contained `pak` as a symlink into renv's cache (because `.Rprofile` activated renv during a prior run), and that target wasn't restored, leaving the symlink dangling.

## Test plan
- [ ] CI run on this PR completes the `Install R dependencies for unfrozen pages` step without "broken symlinks" warnings.
- [ ] Workflow reaches `Publish Quarto Project` and finishes green.
- [ ] No deploy step runs (gated on non-PR events) — `gh-pages` untouched.