### PR TITLE
docs: move slides deadline to Mon 18 May; fix footnote date keys

### DIFF
--- a/schedule.qmd
+++ b/schedule.qmd
@@ -12,7 +12,7 @@ code-link: false
 ## Important dates (more info during the class)
 - Monday the 27^th^ of April: **[Written exam (9h00-11h00, Room Internef-272)]{.underline}**
 - Wednesday the 13^th^ of May: **[Project report deadline]{.underline}**
-- Friday the 15^th^ of May: **[Slides submission deadline]{.underline}**
+- Monday the 18^th^ of May: **[Slides submission deadline]{.underline}**
 - Monday the 18th of May: **[Presentations of the projects]{.underline}**
 :::
 
@@ -96,7 +96,7 @@ d |>
     footnote = "📩 Report & Slides submission at 23:59",
     locations = cells_body(
       columns = 2,
-      rows = date %in% as.Date(c("2026-05-20", "2026-05-24"))
+      rows = date %in% as.Date(c("2026-05-13", "2026-05-18"))
     )
   )
 


### PR DESCRIPTION
## Summary
- Move the project **slides submission deadline** in the "Important dates" callout from Fri 15 May to Mon 18 May (`schedule.qmd:15`), aligning the site with Moodle and resolving the discrepancy a student flagged.
- Fix the `tab_footnote()` row keys in the schedule table (`schedule.qmd:99`): they pointed at `2026-05-20` / `2026-05-24` (rows that don't exist), so the "📩 Report & Slides submission at 23:59" annotation never rendered. Now keyed to `2026-05-13` (report) and `2026-05-18` (slides).

The Google Sheet that backs the rendered table has already been updated separately, so the bullet text and the table render will be in sync after merge.

## Test plan
- [ ] CI run on this PR completes `Build Site` green (post pak-cache fix from #9).
- [ ] After merge, the rendered `schedule.qmd` shows: bullet on 18 May for slides, table row on Mon 18 May, and the "📩 Report & Slides submission at 23:59" footnote attached to the 13-May and 18-May rows.